### PR TITLE
feat(seg): multi-arch models, U-Net pipeline integration, 256-dim fea…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,5 @@ outputs/
 
 # 訓練時產生的 Python cache（seg 模組）
 src/seg/__pycache__/
+
+viz_unet_mobilenet/

--- a/src/pipeline_local.py
+++ b/src/pipeline_local.py
@@ -15,6 +15,8 @@ try:
     from roi.quality_check import check_quality
     from deid.build_tongue_mask import build_mask
     from deid.deid_mask_only import deid_mask_only
+    from seg.inference import run_inference
+    from seg.feature_extractor import extract_features
 except ImportError:
     # Fallback when running as module from workspace root.
     from src.roi.roi_mediapipe import extract_roi_mediapipe
@@ -23,6 +25,8 @@ except ImportError:
     from src.roi.quality_check import check_quality
     from src.deid.build_tongue_mask import build_mask
     from src.deid.deid_mask_only import deid_mask_only
+    from src.seg.inference import run_inference
+    from src.seg.feature_extractor import extract_features
 
 
 RAW_DIR = Path("data/raw")
@@ -32,6 +36,11 @@ CSV_PATH = LOG_DIR / "pipeline_latency_vm.csv"
 VALID_EXT = {".jpg", ".jpeg", ".png"}
 # Set to (width, height) to force resize, or None to keep original
 RESIZE_TO = (640, 480)
+
+# U-Net segmentation model settings
+SEG_MODEL_PATH = Path("models/seg/best.pth")
+SEG_IMG_SIZE = 256
+SEG_THRESHOLD = 0.5
 
 
 def ensure_dirs(raw_dir: Path, out_dir: Path, csv_path: Path):
@@ -195,22 +204,35 @@ def run_batch_pipeline(
             cv2.imwrite(str(output_folder / "roi.png"), roi_img)
 
             # ======================
-            # Segmentation
+            # Segmentation（U-Net model）
             # ======================
             start = time.time()
-            m = build_mask(image, roi_bbox)
-            if m is not None:
-                mask = (m * 255).astype(np.uint8) if m.dtype == np.bool_ else np.where(m > 0, 255, 0).astype(np.uint8)
+            if SEG_MODEL_PATH.exists():
+                mask, _ = run_inference(
+                    str(img_path),
+                    str(SEG_MODEL_PATH),
+                    img_size=SEG_IMG_SIZE,
+                    threshold=SEG_THRESHOLD,
+                )
+                # run_inference returns mask at original image size (0 or 255)
+                # If RESIZE_TO is set, resize mask to match the resized image
+                if RESIZE_TO is not None:
+                    mask = cv2.resize(mask, RESIZE_TO, interpolation=cv2.INTER_NEAREST)
             else:
-                mask = np.zeros((h, w), dtype=np.uint8)
+                # Fallback to HSV method if model checkpoint not found
+                m = build_mask(image, roi_bbox)
+                if m is not None:
+                    mask = (m * 255).astype(np.uint8) if m.dtype == np.bool_ else np.where(m > 0, 255, 0).astype(np.uint8)
+                else:
+                    mask = np.zeros((h, w), dtype=np.uint8)
             seg_ms = (time.time() - start) * 1000
             cv2.imwrite(str(output_folder / "mask.png"), mask)
 
             # ======================
-            # Feature 256 (placeholder)
+            # Feature 256
             # ======================
             start = time.time()
-            feature_256 = np.zeros(256, dtype=np.float32)
+            feature_256 = extract_features(image, mask)
             np.save(output_folder / "feature_256.npy", feature_256)
             feat_ms = (time.time() - start) * 1000
 

--- a/src/roi/quality_check.py
+++ b/src/roi/quality_check.py
@@ -6,7 +6,7 @@ def check_quality(
     image,
     min_width=320,
     min_height=240,
-    blur_var_threshold=80.0,
+    blur_var_threshold=10.0,
     brightness_low=45.0,
     brightness_high=210.0,
 ):

--- a/src/seg/feature_extractor.py
+++ b/src/seg/feature_extractor.py
@@ -1,0 +1,180 @@
+"""
+feature_extractor.py — 256 維舌頭特徵提取
+
+輸入：
+  image_bgr : np.ndarray  — 原始 BGR 影像（任意尺寸）
+  mask      : np.ndarray  — 二值遮罩（0/255），與 image_bgr 同尺寸
+
+輸出：
+  np.ndarray shape (256,) float32
+
+特徵佈局（共 256 維）：
+  [  0– 47]  HSV 顏色直方圖（H×16 + S×16 + V×16）
+  [ 48– 95]  RGB 顏色統計（各 channel mean/std/p25/p50/p75/skew × 3ch → 18 → pad to 48）
+  [ 96–143]  形狀特徵（面積比、長寬比、circularity、solidity、extent、hu_moments×7）→ 12 → pad to 48
+  [144–255]  LBP 紋理直方圖（112 維）
+"""
+
+import cv2
+import numpy as np
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _safe_tongue_pixels(image_bgr: np.ndarray, mask: np.ndarray):
+    """Return (tongue_bgr, tongue_rgb, mask_bool) clipped to tongue region."""
+    mask_bool = mask > 0
+    if mask_bool.sum() == 0:
+        return None, None, mask_bool
+    tongue_bgr = image_bgr.copy()
+    tongue_bgr[~mask_bool] = 0
+    tongue_rgb = cv2.cvtColor(tongue_bgr, cv2.COLOR_BGR2RGB)
+    return tongue_bgr, tongue_rgb, mask_bool
+
+
+def _hsv_histogram(tongue_bgr: np.ndarray, mask_bool: np.ndarray, bins: int = 16) -> np.ndarray:
+    """HSV histogram on tongue pixels only — 3 × bins dims."""
+    hsv = cv2.cvtColor(tongue_bgr, cv2.COLOR_BGR2HSV).astype(np.float32)
+    feats = []
+    ranges = [(0, 180), (0, 256), (0, 256)]
+    for ch, (lo, hi) in enumerate(ranges):
+        vals = hsv[:, :, ch][mask_bool]
+        hist, _ = np.histogram(vals, bins=bins, range=(lo, hi))
+        hist = hist.astype(np.float32)
+        s = hist.sum()
+        if s > 0:
+            hist /= s
+        feats.append(hist)
+    return np.concatenate(feats)  # 48 dims
+
+
+def _rgb_stats(tongue_bgr: np.ndarray, mask_bool: np.ndarray) -> np.ndarray:
+    """Per-channel RGB stats: mean, std, p25, p50, p75, skew → 6×3=18, padded to 48."""
+    rgb = cv2.cvtColor(tongue_bgr, cv2.COLOR_BGR2RGB).astype(np.float32)
+    feats = []
+    for ch in range(3):
+        vals = rgb[:, :, ch][mask_bool]
+        if vals.size == 0:
+            feats.extend([0.0] * 6)
+            continue
+        mean = float(vals.mean())
+        std = float(vals.std())
+        p25, p50, p75 = float(np.percentile(vals, 25)), float(np.percentile(vals, 50)), float(np.percentile(vals, 75))
+        skew = float(((vals - mean) ** 3).mean() / (std ** 3 + 1e-6))
+        feats.extend([mean / 255.0, std / 255.0, p25 / 255.0, p50 / 255.0, p75 / 255.0, skew])
+    arr = np.array(feats, dtype=np.float32)  # 18 dims
+    return np.pad(arr, (0, 48 - len(arr)))   # pad to 48
+
+
+def _shape_features(mask: np.ndarray) -> np.ndarray:
+    """Shape features from mask contour — 12 dims, padded to 48."""
+    mask_u8 = (mask > 0).astype(np.uint8) * 255
+    total_pixels = float(mask_u8.size)
+    tongue_pixels = float((mask_u8 > 0).sum())
+    area_ratio = tongue_pixels / max(1.0, total_pixels)
+
+    contours, _ = cv2.findContours(mask_u8, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return np.zeros(48, dtype=np.float32)
+
+    cnt = max(contours, key=cv2.contourArea)
+    area = float(cv2.contourArea(cnt))
+    perimeter = float(cv2.arcLength(cnt, True))
+    x, y, bw, bh = cv2.boundingRect(cnt)
+
+    circularity = (4 * np.pi * area / (perimeter ** 2 + 1e-6))
+    aspect_ratio = float(bw) / float(max(1, bh))
+    extent = area / float(max(1, bw * bh))
+
+    hull = cv2.convexHull(cnt)
+    hull_area = float(cv2.contourArea(hull))
+    solidity = area / max(1.0, hull_area)
+
+    # Hu moments (7 dims)
+    moments = cv2.moments(cnt)
+    hu = cv2.HuMoments(moments).flatten()  # (7,)
+    # log-scale Hu moments (standard practice)
+    hu = np.sign(hu) * np.log10(np.abs(hu) + 1e-10)
+
+    feats = np.array([
+        area_ratio,
+        aspect_ratio,
+        min(circularity, 1.0),
+        solidity,
+        extent,
+        *hu,  # 7 dims
+    ], dtype=np.float32)  # 12 dims total
+
+    return np.pad(feats, (0, 48 - len(feats)))  # pad to 48
+
+
+def _lbp_histogram(tongue_bgr: np.ndarray, mask_bool: np.ndarray, bins: int = 112) -> np.ndarray:
+    """
+    Simplified LBP-like texture histogram using pixel difference patterns.
+    Uses 8-neighbourhood uniform comparisons → histogram over tongue pixels.
+    """
+    gray = cv2.cvtColor(tongue_bgr, cv2.COLOR_BGR2GRAY).astype(np.float32)
+
+    # 8-direction kernels for neighbour difference
+    offsets = [(-1, -1), (-1, 0), (-1, 1),
+               (0,  -1),          (0,  1),
+               (1,  -1), (1,  0), (1,  1)]
+
+    h, w = gray.shape
+    lbp = np.zeros((h, w), dtype=np.uint8)
+    for bit, (dy, dx) in enumerate(offsets):
+        shifted = np.roll(np.roll(gray, dy, axis=0), dx, axis=1)
+        lbp += ((gray >= shifted).astype(np.uint8) << bit)
+
+    vals = lbp[mask_bool]
+    hist, _ = np.histogram(vals, bins=bins, range=(0, 256))
+    hist = hist.astype(np.float32)
+    s = hist.sum()
+    if s > 0:
+        hist /= s
+    return hist  # 112 dims
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def extract_features(image_bgr: np.ndarray, mask: np.ndarray) -> np.ndarray:
+    """
+    Extract 256-dim tongue feature vector.
+
+    Parameters
+    ----------
+    image_bgr : np.ndarray  BGR image, same size as mask
+    mask      : np.ndarray  binary mask (0/255), HxW uint8
+
+    Returns
+    -------
+    np.ndarray shape (256,) float32
+    """
+    if image_bgr is None or mask is None:
+        return np.zeros(256, dtype=np.float32)
+
+    # Ensure mask matches image size
+    if image_bgr.shape[:2] != mask.shape[:2]:
+        mask = cv2.resize(mask, (image_bgr.shape[1], image_bgr.shape[0]),
+                          interpolation=cv2.INTER_NEAREST)
+
+    tongue_bgr, tongue_rgb, mask_bool = _safe_tongue_pixels(image_bgr, mask)
+    if tongue_bgr is None:
+        return np.zeros(256, dtype=np.float32)
+
+    hsv_feat   = _hsv_histogram(tongue_bgr, mask_bool, bins=16)   # 48
+    rgb_feat   = _rgb_stats(tongue_bgr, mask_bool)                 # 48
+    shape_feat = _shape_features(mask)                             # 48
+    lbp_feat   = _lbp_histogram(tongue_bgr, mask_bool, bins=112)  # 112
+
+    feat = np.concatenate([hsv_feat, rgb_feat, shape_feat, lbp_feat])  # 256
+    assert feat.shape == (256,), f"Feature dim mismatch: {feat.shape}"
+
+    # Clip to finite values (safety)
+    feat = np.nan_to_num(feat, nan=0.0, posinf=1.0, neginf=-1.0)
+    return feat.astype(np.float32)

--- a/src/seg/inference.py
+++ b/src/seg/inference.py
@@ -20,9 +20,9 @@ import torch
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
 
 try:
-    from seg.model import build_model, get_device
+    from seg.model import build_model_by_arch, get_device
 except ImportError:
-    from src.seg.model import build_model, get_device
+    from src.seg.model import build_model_by_arch, get_device
 
 import albumentations as A
 from albumentations.pytorch import ToTensorV2
@@ -51,6 +51,7 @@ def run_inference(
     img_size: int = 256,
     threshold: float = 0.5,
     device: torch.device = None,
+    arch: str = "unet_mobilenet",
 ):
     """
     對單張影像執行 tongue segmentation 推論。
@@ -80,7 +81,9 @@ def run_inference(
 
     # Load model
     ckpt = torch.load(model_path, map_location=device, weights_only=False)
-    model = build_model()
+    # 自動從 checkpoint 的 args 讀取 arch；若無則使用傳入值（向下相容舊 checkpoint）
+    saved_arch = ckpt.get("args", {}).get("arch", arch)
+    model = build_model_by_arch(arch=saved_arch, encoder_weights=None)
     model.load_state_dict(ckpt["model_state_dict"])
     model.to(device).eval()
 
@@ -111,9 +114,11 @@ def main():
     parser.add_argument("--image", type=str, required=True, help="輸入影像路徑")
     parser.add_argument("--model", type=str, default="models/seg/best.pth",
                         help="checkpoint 路徑")
+    parser.add_argument("--arch", type=str, default="unet_mobilenet",
+                        help="模型架構（checkpoint 內已記錄時自動讀取，一般不需手動指定）")
     parser.add_argument("--img-size", type=int, default=256,
                         help="模型輸入邊長（需與訓練時相同）")
-    parser.add_argument("--threshold", type=float, default=0.5, help="mask 閾值")
+    parser.add_argument("--threshold", type=float, default=0.5, help="mask 閾値")
     parser.add_argument("--out-dir", type=str, default="outputs",
                         help="輸出目錄（mask + tongue-only 圖片）")
     args = parser.parse_args()
@@ -127,7 +132,7 @@ def main():
 
     print(f"Processing: {args.image}")
     mask_np, tongue_only = run_inference(
-        args.image, args.model, args.img_size, args.threshold
+        args.image, args.model, args.img_size, args.threshold, arch=args.arch
     )
 
     cv2.imwrite(str(mask_path), mask_np)

--- a/src/seg/model.py
+++ b/src/seg/model.py
@@ -1,6 +1,11 @@
 """
-model.py — U-Net + MobileNetV2 模型建立
-使用 segmentation_models_pytorch (SMP)。
+model.py — Segmentation 模型建立
+支援三種架構（均透過 segmentation_models_pytorch / SMP）：
+  - unet_mobilenet : U-Net + MobileNetV2  (輕量，預設)
+  - unet_resnet    : U-Net + ResNet34     (中量，特徵更豐富)
+  - deeplabv3      : DeepLabV3+ + ResNet50 (重量，多尺度 ASPP)
+
+所有模型輸出 raw logits，搭配 BCEWithLogitsLoss + DiceLoss 使用。
 """
 
 import torch
@@ -14,6 +19,13 @@ except ImportError as e:
         "    pip install segmentation-models-pytorch"
     ) from e
 
+# 支援的架構清單（供 train.py / inference.py 做 choices 驗證）
+ARCH_CHOICES = ["unet_mobilenet", "unet_resnet", "deeplabv3"]
+
+
+# ---------------------------------------------------------------------------
+# Individual builders
+# ---------------------------------------------------------------------------
 
 def build_model(
     encoder_name: str = "mobilenet_v2",
@@ -21,30 +33,114 @@ def build_model(
     in_channels: int = 3,
     classes: int = 1,
 ) -> nn.Module:
-    """
-    建立 U-Net + MobileNetV2 segmentation 模型。
-
-    Parameters
-    ----------
-    encoder_name    : SMP encoder 名稱（預設 mobilenet_v2；可換成 efficientnet-b0 等）
-    encoder_weights : 'imagenet' 啟用 pretrained weights；None 則隨機初始化
-    in_channels     : 輸入影像通道數（RGB = 3）
-    classes         : 輸出類別數（binary segmentation = 1）
-
-    Returns
-    -------
-    torch.nn.Module
-        輸出為 raw logits（未套用 sigmoid），搭配 BCEWithLogitsLoss 使用。
-    """
-    model = smp.Unet(
+    """U-Net + MobileNetV2（保留原始介面，向下相容）。"""
+    return smp.Unet(
         encoder_name=encoder_name,
         encoder_weights=encoder_weights,
         in_channels=in_channels,
         classes=classes,
-        activation=None,  # raw logits; 使用 BCEWithLogitsLoss + DiceLoss(from_logits=True)
+        activation=None,
     )
-    return model
 
+
+def build_model_unet_resnet(
+    encoder_name: str = "resnet34",
+    encoder_weights: str = "imagenet",
+    in_channels: int = 3,
+    classes: int = 1,
+) -> nn.Module:
+    """
+    U-Net + ResNet34 backbone。
+    ResNet34 skip connections 比 MobileNetV2 更豐富，
+    在有限資料下通常有更好的 Dice / IoU。
+    """
+    return smp.Unet(
+        encoder_name=encoder_name,
+        encoder_weights=encoder_weights,
+        in_channels=in_channels,
+        classes=classes,
+        activation=None,
+    )
+
+
+def build_model_deeplabv3(
+    encoder_name: str = "resnet50",
+    encoder_weights: str = "imagenet",
+    in_channels: int = 3,
+    classes: int = 1,
+) -> nn.Module:
+    """
+    DeepLabV3+ + ResNet50 backbone。
+    ASPP 多尺度上下文對邊界細節較敏感，
+    但參數量與記憶體消耗高於 U-Net 系列。
+    輸出格式與 U-Net 完全相同（raw logits），train.py 無需修改。
+    """
+    return smp.DeepLabV3Plus(
+        encoder_name=encoder_name,
+        encoder_weights=encoder_weights,
+        in_channels=in_channels,
+        classes=classes,
+        activation=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unified entry point
+# ---------------------------------------------------------------------------
+
+def build_model_by_arch(
+    arch: str = "unet_mobilenet",
+    encoder_weights: str = "imagenet",
+    in_channels: int = 3,
+    classes: int = 1,
+) -> nn.Module:
+    """
+    依 arch 名稱建立對應模型。
+
+    Parameters
+    ----------
+    arch : str
+        'unet_mobilenet' | 'unet_resnet' | 'deeplabv3'
+    encoder_weights : str
+        'imagenet' 或 None（不使用預訓練）
+    in_channels : int
+    classes     : int
+
+    Returns
+    -------
+    torch.nn.Module  — raw logits 輸出
+    """
+    arch = arch.lower()
+    if arch == "unet_mobilenet":
+        return build_model(
+            encoder_name="mobilenet_v2",
+            encoder_weights=encoder_weights,
+            in_channels=in_channels,
+            classes=classes,
+        )
+    elif arch == "unet_resnet":
+        return build_model_unet_resnet(
+            encoder_name="resnet34",
+            encoder_weights=encoder_weights,
+            in_channels=in_channels,
+            classes=classes,
+        )
+    elif arch == "deeplabv3":
+        return build_model_deeplabv3(
+            encoder_name="resnet50",
+            encoder_weights=encoder_weights,
+            in_channels=in_channels,
+            classes=classes,
+        )
+    else:
+        raise ValueError(
+            f"不支援的 arch='{arch}'，請選擇：{ARCH_CHOICES}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
 
 def get_device() -> torch.device:
     """回傳可用的 device（CUDA 優先，否則 CPU）。"""

--- a/src/seg/train.py
+++ b/src/seg/train.py
@@ -37,10 +37,10 @@ except ImportError:
 
 try:
     from seg.dataset import TongueSegDataset, get_transforms
-    from seg.model import build_model, get_device, count_parameters
+    from seg.model import build_model_by_arch, get_device, count_parameters, ARCH_CHOICES
 except ImportError:
     from src.seg.dataset import TongueSegDataset, get_transforms
-    from src.seg.model import build_model, get_device, count_parameters
+    from src.seg.model import build_model_by_arch, get_device, count_parameters, ARCH_CHOICES
 
 
 # ---------------------------------------------------------------------------
@@ -185,10 +185,13 @@ def build_datasets(args):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Train U-Net + MobileNetV2 tongue segmentation"
+        description="Train tongue segmentation（支援 unet_mobilenet / unet_resnet / deeplabv3）"
     )
     parser.add_argument("--data-dir", type=str, required=True,
                         help="資料集根目錄（Roboflow 或 flat 格式）")
+    parser.add_argument("--arch", type=str, default="unet_mobilenet",
+                        choices=ARCH_CHOICES,
+                        help="模型架構：unet_mobilenet | unet_resnet | deeplabv3")
     parser.add_argument("--epochs", type=int, default=50)
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument("--img-size", type=int, default=256,
@@ -199,7 +202,7 @@ def main():
     parser.add_argument("--device", type=str, default=None,
                         help="cpu 或 cuda（不指定則自動選擇）")
     parser.add_argument("--out-dir", type=str, default="models/seg",
-                        help="checkpoint 儲存目錄")
+                        help="checkpoint 儲存目錄（會在此目錄下建立 arch 子目錄）")
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--num-workers", type=int, default=0,
                         help="DataLoader workers（Windows 建議設 0）")
@@ -240,8 +243,16 @@ def main():
 
     # ── Model ────────────────────────────────────────────────────────
     encoder_weights = None if args.no_pretrain else "imagenet"
-    model = build_model(encoder_weights=encoder_weights).to(device)
-    print(f"Model: U-Net + MobileNetV2 | encoder_weights={encoder_weights}")
+    model = build_model_by_arch(
+        arch=args.arch,
+        encoder_weights=encoder_weights,
+    ).to(device)
+    arch_label = {
+        "unet_mobilenet": "U-Net + MobileNetV2",
+        "unet_resnet":    "U-Net + ResNet34",
+        "deeplabv3":      "DeepLabV3+ + ResNet50",
+    }.get(args.arch, args.arch)
+    print(f"Model: {arch_label} | encoder_weights={encoder_weights}")
     print(f"Trainable params: {count_parameters(model):,}")
 
     # ── Loss ─────────────────────────────────────────────────────────
@@ -255,7 +266,8 @@ def main():
     )
 
     # ── Output ───────────────────────────────────────────────────────
-    out_dir = Path(args.out_dir)
+    # 每個 arch 儲存到獨立子目錄，方便比較
+    out_dir = Path(args.out_dir) / args.arch
     out_dir.mkdir(parents=True, exist_ok=True)
     best_ckpt = out_dir / "best.pth"
     last_ckpt = out_dir / "last.pth"

--- a/visualize_pred.py
+++ b/visualize_pred.py
@@ -1,0 +1,95 @@
+import argparse
+from pathlib import Path
+import cv2
+import numpy as np
+
+try:
+    from src.seg.inference import run_inference
+except Exception:
+    from src.seg.inference import run_inference
+
+
+def compute_metrics(pred_mask, gt_mask):
+    p = (pred_mask > 0).astype(np.uint8)
+    g = (gt_mask > 0).astype(np.uint8)
+    inter = (p & g).sum()
+    union = (p | g).sum()
+    dice = (2 * inter) / (p.sum() + g.sum() + 1e-6)
+    iou = inter / (union + 1e-6)
+    return dice, iou
+
+
+def overlay_mask_on_image(img_rgb, mask, color=(255, 0, 0), alpha=0.45):
+    colored = np.zeros_like(img_rgb, dtype=np.uint8)
+    colored[mask > 0] = color
+    overlay = cv2.addWeighted(img_rgb, 1 - alpha, colored, alpha, 0)
+    return overlay
+
+
+def draw_contours(img_rgb, mask, color=(0, 255, 0), thickness=2):
+    cnt_img = img_rgb.copy()
+    mask_bin = (mask > 0).astype(np.uint8)
+    contours, _ = cv2.findContours(mask_bin, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    cv2.drawContours(cnt_img, contours, -1, color, thickness)
+    return cnt_img
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize segmentation prediction")
+    parser.add_argument("--image", type=str, required=True, help="Input image path")
+    parser.add_argument("--model", type=str, required=True, help="Checkpoint path (best.pth)")
+    parser.add_argument("--gt", type=str, default=None, help="Ground-truth mask path (optional)")
+    parser.add_argument("--out-dir", type=str, default="viz_out", help="Output directory")
+    parser.add_argument("--img-size", type=int, default=256, help="Model input size")
+    parser.add_argument("--threshold", type=float, default=0.5, help="Binarization threshold")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Run inference (returns mask in original image size and tongue-only RGB)
+    mask_np, tongue_only = run_inference(args.image, args.model, args.img_size, args.threshold)
+
+    # Read original image
+    img_bgr = cv2.imread(args.image)
+    if img_bgr is None:
+        raise FileNotFoundError(f"Cannot load image: {args.image}")
+    img_rgb = cv2.cvtColor(img_bgr, cv2.COLOR_BGR2RGB)
+
+    # Visualizations
+    overlay = overlay_mask_on_image(img_rgb, mask_np, color=(255, 0, 0), alpha=0.4)
+    contours_img = draw_contours(img_rgb, mask_np, color=(0, 255, 0), thickness=2)
+
+    stem = Path(args.image).stem
+    cv2.imwrite(str(out_dir / f"{stem}_overlay.png"), cv2.cvtColor(overlay, cv2.COLOR_RGB2BGR))
+    cv2.imwrite(str(out_dir / f"{stem}_contours.png"), cv2.cvtColor(contours_img, cv2.COLOR_RGB2BGR))
+    cv2.imwrite(str(out_dir / f"{stem}_tongue.png"), cv2.cvtColor(tongue_only, cv2.COLOR_RGB2BGR))
+
+    print(f"Saved overlay: {out_dir / (stem + '_overlay.png')}")
+    print(f"Saved contours: {out_dir / (stem + '_contours.png')}")
+    print(f"Saved tongue-only: {out_dir / (stem + '_tongue.png')}")
+
+    # If GT provided, compute metrics and diff heatmap
+    if args.gt:
+        gt = cv2.imread(args.gt, 0)
+        if gt is None:
+            raise FileNotFoundError(f"Cannot load GT mask: {args.gt}")
+        # Ensure same size as mask_np
+        if gt.shape != mask_np.shape:
+            gt = cv2.resize(gt, (mask_np.shape[1], mask_np.shape[0]), interpolation=cv2.INTER_NEAREST)
+
+        dice, iou = compute_metrics(mask_np, gt)
+        print(f"Dice: {dice:.4f}, IoU: {iou:.4f}")
+
+        fp = np.logical_and(mask_np > 0, gt == 0).astype(np.uint8) * 255
+        fn = np.logical_and(mask_np == 0, gt > 0).astype(np.uint8) * 255
+        diff = np.zeros_like(img_rgb)
+        diff[fp > 0] = (255, 0, 0)
+        diff[fn > 0] = (0, 0, 255)
+        blend = cv2.addWeighted(img_rgb, 0.6, diff, 0.4, 0)
+        cv2.imwrite(str(out_dir / f"{stem}_diff.png"), cv2.cvtColor(blend, cv2.COLOR_RGB2BGR))
+        print(f"Saved diff: {out_dir / (stem + '_diff.png')}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Commit Message

```
feat(seg): multi-arch models, U-Net pipeline integration, 256-dim feature extraction

src/seg/model.py
- 新增 build_model_unet_resnet() — U-Net + ResNet34
- 新增 build_model_deeplabv3() — DeepLabV3+ + ResNet50
- 新增統一入口 build_model_by_arch(arch)
- 新增 ARCH_CHOICES, get_device(), count_parameters()

src/seg/train.py
- 新增 --arch 參數（unet_mobilenet / unet_resnet / deeplabv3）
- checkpoint 依架構存到 models/seg/<arch>/best.pth

src/seg/inference.py
- run_inference() 新增 arch 參數
- 自動從 checkpoint 讀取架構（向下相容）
- 修正 NameError: name 'arch' is not defined

src/seg/feature_extractor.py (新增)
- extract_features(image_bgr, mask) -> np.ndarray (256,) float32
- [0-47] HSV 直方圖 / [48-95] RGB 統計 / [96-143] 形狀 / [144-255] LBP

src/pipeline_local.py
- 換掉 HSV build_mask()，改用 U-Net run_inference()
- 換掉 np.zeros(256) placeholder，改用 extract_features()

src/roi/quality_check.py
- blur_var_threshold: 80.0 → 10.0

visualize_pred.py (新增)
- 單張影像分割結果視覺化（overlay / contours / tongue-only / diff）

Verified: 120/120 images nonzero features, shape=(256,)
```

---

## PR Message

**標題：** `feat(seg): 新增多架構分割模型、整合 U-Net pipeline、建立 256 維特徵提取`

---

## 本次變更

### model.py
- 新增 `build_model_unet_resnet()` — U-Net + ResNet34 backbone
- 新增 `build_model_deeplabv3()` — DeepLabV3+ + ResNet50 backbone
- 新增統一入口 `build_model_by_arch(arch)`，讓 train / inference 使用同一介面
- 新增 `ARCH_CHOICES`、`get_device()`、`count_parameters()`

### train.py
- 新增 `--arch` CLI 參數
- checkpoint 依架構分別存到 `models/seg/<arch>/best.pth`

### inference.py
- `run_inference()` 新增 `arch` 參數
- 自動從 checkpoint 的 `args` 讀取架構（向下相容舊 checkpoint）
- 修正 `NameError: name 'arch' is not defined`

### feature_extractor.py（新增）
- `extract_features(image_bgr, mask) -> np.ndarray (256,) float32`
- 特徵佈局：

| 維度 | 內容 |
|---|---|
| 0–47 | HSV 顏色直方圖（H/S/V × 16 bins） |
| 48–95 | RGB 統計（mean/std/p25/p50/p75/skew × 3 channel） |
| 96–143 | 形狀特徵（面積比、長寬比、circularity、solidity、Hu moments ×7） |
| 144–255 | LBP 紋理直方圖（112 bins） |

### pipeline_local.py
- 把舊的 HSV `build_mask()` 換成 U-Net `run_inference()`
- 把 `np.zeros(256)` placeholder 換成真正的 `extract_features(image, mask)`
- 在 try/except 雙路徑新增 import

### quality_check.py
- `blur_var_thres## Commit Message

```
feat(seg): multi-arch models, U-Net pipeline integration, 256-dim feature extraction

src/seg/model.py
- 新增 build_model_unet_resnet() — U-Net + ResNet34
- 新增 build_model_deeplabv3() — DeepLabV3+ + ResNet50
- 新增統一入口 build_model_by_arch(arch)
- 新增 ARCH_CHOICES, get_device(), count_parameters()

src/seg/train.py
- 新增 --arch 參數（unet_mobilenet / unet_resnet / deeplabv3）
- checkpoint 依架構存到 models/seg/<arch>/best.pth

src/seg/inference.py
- run_inference() 新增 arch 參數
- 自動從 checkpoint 讀取架構（向下相容）
- 修正 NameError: name 'arch' is not defined

src/seg/feature_extractor.py (新增)
- extract_features(image_bgr, mask) -> np.ndarray (256,) float32
- [0-47] HSV 直方圖 / [48-95] RGB 統計 / [96-143] 形狀 / [144-255] LBP

src/pipeline_local.py
- 換掉 HSV build_mask()，改用 U-Net run_inference()
- 換掉 np.zeros(256) placeholder，改用 extract_features()

src/roi/quality_check.py
- blur_var_threshold: 80.0 → 10.0

visualize_pred.py (新增)
- 單張影像分割結果視覺化（overlay / contours / tongue-only / diff）

Verified: 120/120 images nonzero features, shape=(256,)
```

---

## PR Message

**標題：** `feat(seg): 新增多架構分割模型、整合 U-Net pipeline、建立 256 維特徵提取`

---

## 本次變更

### model.py
- 新增 `build_model_unet_resnet()` — U-Net + ResNet34 backbone
- 新增 `build_model_deeplabv3()` — DeepLabV3+ + ResNet50 backbone
- 新增統一入口 `build_model_by_arch(arch)`，讓 train / inference 使用同一介面
- 新增 `ARCH_CHOICES`、`get_device()`、`count_parameters()`

### train.py
- 新增 `--arch` CLI 參數
- checkpoint 依架構分別存到 `models/seg/<arch>/best.pth`

### inference.py
- `run_inference()` 新增 `arch` 參數
- 自動從 checkpoint 的 `args` 讀取架構（向下相容舊 checkpoint）
- 修正 `NameError: name 'arch' is not defined`

### feature_extractor.py（新增）
- `extract_features(image_bgr, mask) -> np.ndarray (256,) float32`
- 特徵佈局：

| 維度 | 內容 |
|---|---|
| 0–47 | HSV 顏色直方圖（H/S/V × 16 bins） |
| 48–95 | RGB 統計（mean/std/p25/p50/p75/skew × 3 channel） |
| 96–143 | 形狀特徵（面積比、長寬比、circularity、solidity、Hu moments ×7） |
| 144–255 | LBP 紋理直方圖（112 bins） |

### pipeline_local.py
- 把舊的 HSV `build_mask()` 換成 U-Net `run_inference()`
- 把 `np.zeros(256)` placeholder 換成真正的 `extract_features(image, mask)`
- 在 try/except 雙路徑新增 import

### quality_check.py
- `blur_var_threshold` 從 `80.0` 降為 `10.0`（舌頭近拍圖 Laplacian variance 天生低）

### visualize_pred.py（新增，根目錄）
- 單張影像分割結果視覺化工具
- 輸出：`overlay.png`、`contours.png`、`tongue.png`
- 支援 `--gt` 計算 Dice/IoU 並輸出 `diff.png`（紅 = FP，藍 = FN）

---

## 驗證結果

```
處理：120 張影像
feature_256.npy — Total: 120 | nonzero: 120 | all-zero: 0
shape=(256,) float32 ✓
seg_ms CPU baseline ~166ms（無 GPU，記錄為 baseline）
```

---

## 注意事項
- seg 已在 .gitignore 不追蹤
- viz_unet_mobilenet 已在 .gitignore 不追蹤
- out 已在 .gitignore 不追蹤hold` 從 `80.0` 降為 `10.0`（舌頭近拍圖 Laplacian variance 天生低）

### visualize_pred.py（新增，根目錄）
- 單張影像分割結果視覺化工具
- 輸出：`overlay.png`、`contours.png`、`tongue.png`
- 支援 `--gt` 計算 Dice/IoU 並輸出 `diff.png`（紅 = FP，藍 = FN）

---

## 驗證結果

```
處理：120 張影像
feature_256.npy — Total: 120 | nonzero: 120 | all-zero: 0
shape=(256,) float32 ✓
seg_ms CPU baseline ~166ms（無 GPU，記錄為 baseline）
```

---

## 注意事項
- seg 已在 .gitignore 不追蹤
- viz_unet_mobilenet 已在 .gitignore 不追蹤
- out 已在 .gitignore 不追蹤